### PR TITLE
fix cors error: the value of the 'Access-Control-Allow-Credentials'

### DIFF
--- a/src/core/headers/header.php
+++ b/src/core/headers/header.php
@@ -300,7 +300,7 @@ class header extends server implements interfaces\optionsInterface
         ));
 
         $this->setHeader('Access-Control-Allow-Credentials', array(
-            true,
+            'true',
         ));
 
         if (!array_key_exists('Access-Control-Allow-Methods', $auth_headers)) {


### PR DESCRIPTION
Access-Control-Allow-Credentials header value is expected to be 'true' according to the [documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Credentials#syntax).

The error we get:
access to fetch a https://uk.vudoo.io/backmagic/connections from origin https://vudoo.io has been blocked by CORS policy: Response to preflight request doesn't pass access control check: the value of the 'Access-Control-Allow-Credentials' header in the response is '1' which must be 'true' when request's credential mode is 'include' 

<img width="1132" height="124" alt="Screenshot 2025-09-01 at 11 16 13 am" src="https://github.com/user-attachments/assets/36cfa659-bcb1-40f0-be9a-8e1747368b9b" />

Before:
<img width="1058" height="328" alt="Screenshot 2025-09-01 at 11 17 30 am" src="https://github.com/user-attachments/assets/4e2aa991-f4e6-491e-92d0-5fc48fe3d569" />

After:
<img width="1071" height="372" alt="Screenshot 2025-09-01 at 11 18 45 am" src="https://github.com/user-attachments/assets/32637ed9-d713-43e8-819a-788cbff137d8" />
