### PR TITLE
Feature/expose pdo transactions api

### DIFF
--- a/src/core/connect/DB.php
+++ b/src/core/connect/DB.php
@@ -198,4 +198,19 @@ class DB
         header("Status: 500 Internal Server Error");
         return $exception;
     }
+
+    public function beginTransaction()
+    {
+        $this->pdo->beginTransaction();
+    }
+
+    public function commit()
+    {
+        $this->pdo->commit();
+    }
+
+    public function rollBack()
+    {
+        $this->pdo->rollBack();
+    }
 }


### PR DESCRIPTION
Expose PDO transactions API so it can be used for grouping a series of database operations.
It ensures data integrity by guaranteeing that all operations either succeed completely or fail entirely, leaving the database unchanged.

Usage example:
```
try {
            $sql = new sql();
            $sql->getDbClient()->DB()->beginTransaction();

            $sql->insert('vudoo_affiliates')
                ->field('integration_request_id')->value(93)
                ->field('token_id')->value(0)
                ->field('name')->value(sprintf('af_%d', time()))
                ->field('code')->value(sprintf('cd_%d', time()))
            ->writeEntry();

            $sql->insert('vudoo_affiliates')
                ->field('integration_request_id')->value(93)
                ->field('token_id')->value(0)
                ->field('name')->value(sprintf('af_%d', time() + 1))
                ->field('code')->value(sprintf('cd_%d', time() + 1))
                ->writeEntry();

            $sql->getDbClient()->DB()->commit();
        } catch (\Exception $e) {
            $sql->getDbClient()->DB()->rollBack();
        }
```

We can also improve DB client declared in the platform codebase with the support of transaction methods to simplify usage:
```
$sql->beginTransaction();
```
instead of
```
$sql->getDbClient()->DB()->beginTransaction();
```